### PR TITLE
Changes for a CMake integration

### DIFF
--- a/bindings/python/scripts/generate.py
+++ b/bindings/python/scripts/generate.py
@@ -1,6 +1,8 @@
+from typing import Any, List, Dict
+import os
+
 from context import scripts
 import scripts.utils as utils
-from typing import Any, List, Dict
 
 
 class bind:
@@ -427,12 +429,15 @@ def main():
     for source in args.files:
         source = utils.get_realpath(path=source)
         lines_to_write = generate(module_name="pcl", source=source)
+        output_dir = utils.join_path(args.pybind11_output_path, "pybind11-gen")
         output_filepath = utils.get_output_path(
             source=source,
-            output_dir=utils.join_path(args.pybind11_output_path, "pybind11-gen"),
+            output_dir=output_dir,
             split_from="json",
             extension=".cpp",
         )
+        out_rel_path = os.path.relpath(output_filepath, args.pybind11_output_path)
+        print(f"Producing ./{out_rel_path}")
         utils.write_to_file(filename=output_filepath, linelist=lines_to_write)
 
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -268,7 +268,7 @@ def main():
         parsed_info = parse_file(source, args.compilation_database_path)
 
         # Output path for dumping the parsed info into a json file
-        output_dir=utils.join_path(args.json_output_path, "json")
+        output_dir = utils.join_path(args.json_output_path, "json")
         output_filepath = utils.get_output_path(
             source=source,
             output_dir=output_dir,

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import clang.cindex as clang
 
@@ -267,12 +268,15 @@ def main():
         parsed_info = parse_file(source, args.compilation_database_path)
 
         # Output path for dumping the parsed info into a json file
+        output_dir=utils.join_path(args.json_output_path, "json")
         output_filepath = utils.get_output_path(
             source=source,
-            output_dir=utils.join_path(args.json_output_path, "json"),
-            split_from="pcl",
+            output_dir=output_dir,
+            split_from=args.project_root,
             extension=".json",
         )
+        out_rel_path = os.path.relpath(output_filepath, args.json_output_path)
+        print(f"Producing ./{out_rel_path}")
 
         # Dump the parsed info at output path
         utils.dump_json(filepath=output_filepath, info=parsed_info)

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -35,7 +35,9 @@ def get_output_path(source, output_dir, split_from, extension):
     """
 
     # split_path: contains the path after splitting. For split_path = pcl, contains the path as seen in the pcl directory
-    _, split_path = source.split(f"{split_from}{os.sep}", 1)
+    split_path = source.split(f"{split_from}{os.sep}", 1)
+    # handle the case where there's nothing to split
+    split_path = split_path[1] if len(split_path) == 2 else split_path[0]
 
     # relative_dir: contains the relative output path for the json file
     # source_filename: contains the source's file name
@@ -93,8 +95,13 @@ def parse_arguments(script):
         )
         parser.add_argument(
             "--json_output_path",
-            default=get_parent_directory(file=__file__),
+            default=os.getcwd(),
             help="Output path for generated json",
+        )
+        parser.add_argument(
+            "--project-root",
+            default=os.path.dirname(os.getcwd()),
+            help="Path to split to make output paths shorter",
         )
         parser.add_argument("files", nargs="+", help="The source files to parse")
 
@@ -103,7 +110,7 @@ def parse_arguments(script):
         parser.add_argument("files", nargs="+", help="JSON input")
         parser.add_argument(
             "--pybind11_output_path",
-            default=get_parent_directory(file=__file__),
+            default=os.getcwd(),
             help="Output path for generated cpp",
         )
 

--- a/bindings/python/tests/test_project/CMakeLists.txt
+++ b/bindings/python/tests/test_project/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.10)
+project(clang_bind_test VERSION 0.0.1 LANGUAGES CXX)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_library(simple src/simple.cpp)
+target_include_directories(simple PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+  $<INSTALL_INTERFACE:include/>
+)

--- a/bindings/python/tests/test_project/include/clang_bind_test/function.hpp
+++ b/bindings/python/tests/test_project/include/clang_bind_test/function.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace simple {
+int add(int a, int b);
+}  // namespace simple

--- a/bindings/python/tests/test_project/src/simple.cpp
+++ b/bindings/python/tests/test_project/src/simple.cpp
@@ -1,0 +1,5 @@
+#include <clang_bind_test/function.hpp>
+
+namespace simple {
+int add(int a, int b) { return a + b; }
+}  // namespace simple


### PR DESCRIPTION
- Changes to make it more intuitive to use
- Add a sample (simple?) CMake project

Current usage (<> means path to)
* build the project
* goto build directory
* `python <parse> --com ./ ../src/simple.cpp`
* `python <generate> json/src/simple.json`

TODO (future PRs)
* single script for end-to-end generation
* CMake generator (or compile_database generator)
* compile_database_path is actually path to the dir containing it
